### PR TITLE
Add portable kinds

### DIFF
--- a/src/lib/opendiff.f90
+++ b/src/lib/opendiff.f90
@@ -1,52 +1,65 @@
+!< opendiff: Open Fortran Library for PDE solving (OpenFoam done right).
 module opendiff
-!------------------------------------------------------
+    !< opendiff: Open Fortran Library for PDE solving (OpenFoam done right).
+    use opendiff_kinds
+
+    implicit none
+    private
+    public :: mesh
+    public :: mesh_fd_1d
+    public :: field
+    public :: field_fd_1d
+
     type, abstract :: mesh
-        character(128) :: description
+        !< Abstract class for *mesh* handling.
+        character(128) :: description !< Mesh description.
         contains
-            procedure(abstract_meshinit) , deferred :: init 
-            procedure(abstract_meshoutput) , deferred :: output 
+            procedure(abstract_meshinit),    deferred :: init   !< Initilize mesh.
+            procedure(abstract_meshoutput) , deferred :: output !< Output mesh data.
     endtype mesh
     type, extends(mesh) :: mesh_fd_1d
-        integer :: n  ! number of points
-        integer :: ng ! number of ghost points
-        integer :: s  ! number of replicas for steps/stages
-        real    :: h  ! cell size
+        !< Finite difference 1D class for *mesh* handling.
+        integer(I4P) :: n  !< number of points.
+        integer(I4P) :: ng !< number of ghost points.
+        integer(I4P) :: s  !< number of replicas for steps/stages.
+        real(R8P)    :: h  !< cell size.
         contains
-            procedure :: init => mesh_fd_1d_init
-            procedure :: output => mesh_fd_1d_output
+            procedure :: init => mesh_fd_1d_init     !< Initilize mesh.
+            procedure :: output => mesh_fd_1d_output !< Output mesh data.
     endtype mesh_fd_1d
-!------------------------------------------------------
+
     type, abstract :: field
-        character(128) :: description
-        class(mesh), pointer :: m  ! pointer to the mesh of the field
+        !< Abstract class for *field* handling.
+        character(128)       :: description !< Field description.
+        class(mesh), pointer :: m           !< Pointer to the mesh of the field.
         contains
-            procedure(abstract_fieldinit)                , deferred :: init 
-            procedure(abstract_fieldoutput)              , deferred :: output
-            procedure(abstract_fieldadd)                 , deferred :: add
-            procedure(abstract_fieldassign)              , deferred :: assign
+            procedure(abstract_fieldinit)                , deferred :: init   !< Initilize field.
+            procedure(abstract_fieldoutput)              , deferred :: output !< Output field data.
+            procedure(abstract_fieldadd)                 , deferred :: add    !< Add fields.
+            procedure(abstract_fieldassign)              , deferred :: assign !< Assign fields.
             !procedure(abstract_fieldsub)                 , deferred :: sub
             !RIMETTERE procedure(abstract_fieldmul)                 , deferred :: mul
             !RIMETTERE procedure(abstract_fieldmulreal)             , deferred :: mulreal
             !RIMETTERE procedure(abstract_fieldrealmul) , pass(rhs) , deferred :: realmul
             !RIMETTERE !procedure :: assig       => assig_mesh_fd_1d_scal
             !RIMETTERE !procedure :: assigreal   => assigreal_mesh_fd_1d_scal
-            generic, public :: operator(+)  => add                             
+            generic, public :: operator(+)  => add
             !RIMETTERE generic, public :: operator(*)  => mul, realmul, mulreal
             generic, public :: assignment(=) => assign
     endtype field
     type, extends(field) :: field_fd_1d
-        real, allocatable, dimension(:) :: val
+        !< Finite difference 1D class for *field* handling.
+        real(R8P), allocatable, dimension(:) :: val !< Field value.
         contains
-            procedure :: init    => field_fd_1d_init
-            procedure :: output  => field_fd_1d_output
-            procedure :: add     => field_fd_1d_add
-            procedure :: assign  => field_fd_1d_assign
+            procedure :: init    => field_fd_1d_init   !< Initilize field.
+            procedure :: output  => field_fd_1d_output !< Output field data.
+            procedure :: add     => field_fd_1d_add    !< Add fields.
+            procedure :: assign  => field_fd_1d_assign !< Assign fields.
             !RIMETTERE procedure :: sub     => field_fd_1d_sub
             !RIMETTERE procedure :: mul     => field_fd_1d_mul
             !RIMETTERE procedure :: mulreal => field_fd_1d_mulreal
             !RIMETTERE procedure :: realmul => field_fd_1d_realmul
     endtype field_fd_1d
-!------------------------------------------------------
 !RIMETTERE     type, abstract :: integrator
 !RIMETTERE         character(128) :: description
 !RIMETTERE         real :: dt
@@ -62,7 +75,6 @@ module opendiff
 !RIMETTERE !        contains
 !RIMETTERE !            procedure :: integrate => lsrk_integrate
 !RIMETTERE !    endtype lsrk_integrator
-!------------------------------------------------------
 !RIMETTERE    type, abstract :: spatialop
 !RIMETTERE        character(128) :: description
 !RIMETTERE        contains
@@ -80,55 +92,54 @@ module opendiff
 !RIMETTERE    endtype equation
 !RIMETTERE    ! the concrete types are implemented at application level (by the user)
 !RIMETTERE    ! predefined examples might be provided as well
-!------------------------------------------------------
     abstract interface
         function abstract_meshinit(this) result(res)
-            import :: mesh
-            class(mesh) :: this
-            integer :: res
+            import :: I4P, mesh
+            class(mesh), intent(inout) :: this
+            integer(I4P)               :: res
         end function abstract_meshinit
     endinterface
 
     abstract interface
         function abstract_meshoutput(this) result(res)
-            import :: mesh
-            class(mesh) :: this
-            integer :: res
+            import :: I4P, mesh
+            class(mesh), intent(in) :: this
+            integer(I4P)            :: res
         end function abstract_meshoutput
     endinterface
 
     abstract interface
         function abstract_fieldinit(this, fieldmesh) result(res)
-            import :: field, mesh
-            class(field) :: this
-            class(mesh), target :: fieldmesh
-            integer :: res
+            import :: field, I4P, mesh
+            class(field), intent(inout)      :: this
+            class(mesh),  intent(in), target :: fieldmesh
+            integer(I4P)                     :: res
         end function abstract_fieldinit
     endinterface
 
     abstract interface
         function abstract_fieldoutput(this, filename) result(res)
-            import :: field
-            class(field) :: this
-            character(len=*) :: filename
-            integer :: res
+            import :: field, I4P
+            class(field),     intent(in) :: this
+            character(len=*), intent(in) :: filename
+            integer(I4P)                 :: res
         end function abstract_fieldoutput
     endinterface
 
     abstract interface
         function abstract_fieldadd(lhs, rhs) result(opr)
             import :: field
-            class(field), intent(in) :: lhs
-            class(field), target, intent(in) :: rhs
-            class(field), allocatable :: opr
+            class(field), intent(in)         :: lhs
+            class(field), intent(in), target :: rhs
+            class(field), allocatable        :: opr
         end function abstract_fieldadd
     endinterface
 
     abstract interface
-        subroutine abstract_fieldassign(lhs,rhs) 
+        subroutine abstract_fieldassign(lhs,rhs)
             import :: field
-            class(field), intent(inout) :: lhs
-            class(field), target, intent(in) :: rhs
+            class(field), intent(inout)      :: lhs
+            class(field), intent(in), target :: rhs
         end subroutine abstract_fieldassign
     endinterface
 
@@ -136,7 +147,7 @@ module opendiff
 !RIMETTERE        function abstract_integrate(this, inp, equ, t) result(res)
 !RIMETTERE            import :: integrator, field, equation
 !RIMETTERE            class(integrator) :: this
-!RIMETTERE            class(field)      :: inp 
+!RIMETTERE            class(field)      :: inp
 !RIMETTERE            class(equation)   :: equ
 !RIMETTERE            integer :: res
 !RIMETTERE            real :: t
@@ -163,33 +174,35 @@ module opendiff
 !RIMETTERE    endinterface
 !------------------------------------------------------
 contains
-
     function mesh_fd_1d_init(this) result(res)
-        class(mesh_fd_1d) :: this
-        integer :: res
+        !< Initialize finite difference 1D mesh.
+        class(mesh_fd_1d), intent(inout) :: this !< The mesh.
+        integer(I4P)                     :: res  !< Result (error code?).
         this%n  = 50
         this%ng = 2
         this%s  = 1
-        this%h  = 0.1
+        this%h  = 0.1_R8P
         res = 0
     end function mesh_fd_1d_init
 
     function mesh_fd_1d_output(this) result(res)
-        class(mesh_fd_1d) :: this
-        integer :: res
-        print*,"n: ",this%n
-        print*,"ng: ",this%ng
-        print*,"s: ",this%s 
-        print*,"h: ",this%h
+        !< Output mesh data.
+        class(mesh_fd_1d), intent(in) :: this !< The mesh.
+        integer(I4P)                  :: res  !< Result (error code?).
+        print*,"n: ", this%n
+        print*,"ng: ", this%ng
+        print*,"s: ", this%s
+        print*,"h: ", this%h
         res = 0
     end function mesh_fd_1d_output
 
     function field_fd_1d_init(this, fieldmesh) result(res)
-        class(field_fd_1d) :: this
-        class(mesh), target :: fieldmesh
-        class(mesh_fd_1d), pointer :: fieldmesh_cur
-        integer :: res
-        integer :: n
+        !< Initialize finite difference 1D field.
+        class(field_fd_1d), intent(inout)      :: this          !< The field.
+        class(mesh),        intent(in), target :: fieldmesh     !< Mesh of the field.
+        integer(I4P)                           :: res           !< Result (error code?).
+        class(mesh_fd_1d), pointer             :: fieldmesh_cur !< Dummy pointer for mesh.
+        integer(I4P)                           :: n             !< Counter.
         select type(fieldmesh)
             type is(mesh_fd_1d)
                 fieldmesh_cur => fieldmesh
@@ -204,9 +217,10 @@ contains
     end function field_fd_1d_init
 
     function field_fd_1d_output(this, filename) result(res)
-        class(field_fd_1d) :: this
-        character(len=*) :: filename
-        integer :: res
+        !< Output field data.
+        class(field_fd_1d), intent(in) :: this     !< The field.
+        character(len=*),   intent(in) :: filename !< Output file name.
+        integer(I4P)                   :: res      !< Result (error code?).
         open(unit=11,file=filename)
         write(11,*) this%val(:)
         close(11)
@@ -214,20 +228,19 @@ contains
     end function field_fd_1d_output
 
     function field_fd_1d_add(lhs, rhs) result(opr)
-        class(mesh_fd_1d), pointer :: mesh_cur
-        class(field_fd_1d), intent(in) :: lhs
-        class(field), target, intent(in) :: rhs
-        class(field_fd_1d), pointer :: rhs_cur
-        class(field), allocatable, target :: opr
-        class(field_fd_1d), pointer :: opr_cur
-
+        !< Add fields.
+        class(field_fd_1d), intent(in)         :: lhs      !< Left hand side.
+        class(field),       intent(in), target :: rhs      !< Left hand side.
+        class(field), allocatable, target      :: opr      !< Operator result.
+        class(field_fd_1d), pointer            :: rhs_cur  !< Dummy pointer for rhs.
+        class(field_fd_1d), pointer            :: opr_cur  !< Dummy pointer for operator result.
+        class(mesh_fd_1d),  pointer            :: mesh_cur !< Dummy pointer for mesh.
         select type(rhs)
             type is(field_fd_1d)
                 rhs_cur => rhs
             class default
                STOP 'Error passing field to add'
         end select
-
         allocate(field_fd_1d :: opr)
         select type(opr)
             type is(field_fd_1d)
@@ -235,7 +248,6 @@ contains
             class default
                STOP 'Error passing field to add'
         end select
-
         associate(mm => lhs%m)
             select type(mm)
                 type is(mesh_fd_1d)
@@ -244,26 +256,23 @@ contains
                    STOP 'Error getting mesh'
             end select
         end associate
-
         allocate(opr_cur%val(1:mesh_cur%n))
         opr_cur%m => lhs%m
         opr_cur%val = lhs%val + rhs_cur%val
-
     end function field_fd_1d_add
 
-    subroutine field_fd_1d_assign(lhs, rhs) 
-        class(field_fd_1d), intent(inout) :: lhs
-        class(field), target, intent(in) :: rhs
-        class(field_fd_1d), pointer :: rhs_cur
-        class(mesh_fd_1d), pointer :: mesh_cur
-
+    subroutine field_fd_1d_assign(lhs, rhs)
+        !< Assign fields.
+        class(field_fd_1d), intent(inout)      :: lhs      !< Left hand side.
+        class(field),       intent(in), target :: rhs      !< Right hand side.
+        class(field_fd_1d), pointer            :: rhs_cur  !< Dummy pointer for rhs.
+        class(mesh_fd_1d),  pointer            :: mesh_cur !< Dummy pointer for mesh.
         select type(rhs)
             type is(field_fd_1d)
                 rhs_cur => rhs
             class default
                STOP 'Error passing field to assign'
         end select
-
         associate(mm => rhs%m)
             select type(mm)
                 type is(mesh_fd_1d)
@@ -272,14 +281,11 @@ contains
                    STOP 'Error getting mesh'
             end select
         end associate
-
         if(allocated(lhs%val)) deallocate(lhs%val)
         allocate(lhs%val(1:mesh_cur%n))
         lhs%m   => rhs_cur%m
         lhs%val = rhs_cur%val
-
     end subroutine field_fd_1d_assign
-
 !RIMETTERE    function field_fd_1d_mul(lhs, rhs) result(opr)
 !RIMETTERE        class(field_fd_1d) :: lhs, rhs
 !RIMETTERE        type(field_fd_1d) :: opr
@@ -320,8 +326,8 @@ contains
 !RIMETTERE    !    integer, parameter :: registers=2
 !RIMETTERE    !    type(mesh_fd_1d_scal)  :: stage(1:registers)
 !RIMETTERE    !    type(error) :: res
-!RIMETTERE    !    real :: t        
-!RIMETTERE    !    integer :: s 
+!RIMETTERE    !    real :: t
+!RIMETTERE    !    integer :: s
 !RIMETTERE!   !    computing stages
 !RIMETTERE    !    stage(1) = inp
 !RIMETTERE    !    stage(2) = inp*0.
@@ -347,5 +353,4 @@ contains
 !RIMETTERE        res%field(1)     = (inp%field(2) - inp%field(inp%n))/(2.*inp%h)
 !RIMETTERE        res%field(inp%n) = (inp%field(1) - inp%field(inp%n-1))/(2.*inp%h)
 !RIMETTERE    end function firstderive_operate
-
 end module opendiff

--- a/src/lib/opendiff_kinds.f90
+++ b/src/lib/opendiff_kinds.f90
@@ -1,0 +1,24 @@
+!< opendiff kinds: definition of reals and integer kind parameters of opendiff library.
+module opendiff_kinds
+!< opendiff kinds: definition of reals and integer kind parameters of opendiff library.
+
+implicit none
+private
+public :: R8P
+public :: R4P
+public :: R_P
+public :: I8P
+public :: I4P
+public :: I2P
+public :: I1P
+public :: I_P
+
+integer, parameter :: R8P  = selected_real_kind(15,307)  !< 15  digits, range \([10^{-307} , 10^{+307}  - 1]\); 64 bits.
+integer, parameter :: R4P  = selected_real_kind(6,37)    !< 6   digits, range \([10^{-37}  , 10^{+37}   - 1]\); 32 bits.
+integer, parameter :: R_P  = R8P                         !< Default real precision.
+integer, parameter :: I8P  = selected_int_kind(18)       !< Range \([-2^{63},+2^{63} - 1]\), 19 digits plus sign; 64 bits.
+integer, parameter :: I4P  = selected_int_kind(9)        !< Range \([-2^{31},+2^{31} - 1]\), 10 digits plus sign; 32 bits.
+integer, parameter :: I2P  = selected_int_kind(4)        !< Range \([-2^{15},+2^{15} - 1]\), 5  digits plus sign; 16 bits.
+integer, parameter :: I1P  = selected_int_kind(2)        !< Range \([-2^{7} ,+2^{7}  - 1]\), 3  digits plus sign; 8  bits.
+integer, parameter :: I_P  = I4P                         !< Default integer precision.
+endmodule opendiff_kinds


### PR DESCRIPTION
Add portable kinds

Add portable kinds: for future development I think it is more safe to
adopt portable parametrized kinds for integers and reals.

Some comments have been added to prepare to API documentation.

Francesco's sources have not been modified in their implementation: just
some trivial, estetic changes. 
